### PR TITLE
flake.nix: add packages to devenv for WCH dev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
       ];
 
       perSystem = {
+        self',
         config,
         pkgs,
         system,
@@ -53,6 +54,17 @@
           programs.treefmt.package = config.treefmt.build.wrapper;
 
           imports = [./devenv.nix];
+
+          packages = (with pkgs; [
+            cmake
+            ninja
+          ]) ++ (with self'.packages; [
+            mrs-openocd
+            mrs-riscv-embedded-gcc
+            mrs-riscv-embedded-gcc12
+            wchisp
+            wlink
+          ]);
         };
 
         packages = let


### PR DESCRIPTION
This PR updates the devenv declared in `flake.nix` with packages for developing the WCH C code.

Adds packages:

- MounRiver Studio toolchain programs (riscv-none-embed- and riscv-none-elf- toolchains, openocd), for compiling for WCH RISC-V MCUs.
- ch32-rs programs (wchisp, wlink), for flashing & debugging.
- cmake & ninja, for C development.